### PR TITLE
DI-6121 add examples for customhttp

### DIFF
--- a/sample-data/Custom HTTP/users/behaviors/app/FirstSession.json
+++ b/sample-data/Custom HTTP/users/behaviors/app/FirstSession.json
@@ -1,0 +1,18 @@
+{
+    "event_type": "users.behaviors.app.FirstSession",
+    "id": "a1234567-89ab-cdef-0123-456789abcdef",
+    "time": 1477502783,
+    "user": {
+      "user_id": "0123456789abcdef01234567",
+      "external_user_id": "user_id",
+      "device_id": "fedcba87-6543-210f-fedc-ba9876543210",
+      "timezone": "America/Chicago"
+    },
+    "properties": {
+      "app_id": "01234567-89ab-cdef-0123-456789abcdef",
+      "platform": "ios",
+      "os_version": "iOS 10.3.1",
+      "device_model": "iPhone 7 Plus",
+      "session_id": "b1234567-89ab-cdef-0123-456789abcdef"
+    }
+  }

--- a/sample-data/Custom HTTP/users/behaviors/app/SessionEnd.json
+++ b/sample-data/Custom HTTP/users/behaviors/app/SessionEnd.json
@@ -1,0 +1,18 @@
+{
+    "event_type": "users.behaviors.app.SessionEnd",
+    "id": "a1234567-89ab-cdef-0123-456789abcdef",
+    "time": 1477502783,
+    "user": {
+      "user_id": "0123456789abcdef01234567",
+      "external_user_id": "user_id",
+      "device_id": "fedcba87-6543-210f-fedc-ba9876543210"
+    },
+    "properties": {
+      "app_id": "01234567-89ab-cdef-0123-456789abcdef",
+      "platform": "ios",
+      "os_version": "iOS 10.3.1",
+      "device_model": "iPhone 7 Plus",
+      "session_id": "b1234567-89ab-cdef-0123-456789abcdef",
+      "duration": 4.5
+    }
+  }

--- a/sample-data/Custom HTTP/users/behaviors/app/SessionStart.json
+++ b/sample-data/Custom HTTP/users/behaviors/app/SessionStart.json
@@ -1,0 +1,17 @@
+{
+    "event_type": "users.behaviors.app.SessionStart",
+    "id": "a1234567-89ab-cdef-0123-456789abcdef",
+    "time": 1477502783,
+    "user": {
+      "user_id": "0123456789abcdef01234567",
+      "external_user_id": "user_id",
+      "device_id": "fedcba87-6543-210f-fedc-ba9876543210"
+    },
+    "properties": {
+      "app_id": "01234567-89ab-cdef-0123-456789abcdef",
+      "platform": "ios",
+      "os_version": "iOS 10.3.1",
+      "device_model": "iPhone 7 Plus",
+      "session_id": "b1234567-89ab-cdef-0123-456789abcdef"
+    }
+  }

--- a/sample-data/Custom HTTP/users/behaviors/subscription/GlobalStateChange.json
+++ b/sample-data/Custom HTTP/users/behaviors/subscription/GlobalStateChange.json
@@ -1,0 +1,28 @@
+{
+    "event_type": "users.behaviors.subscription.GlobalStateChange",
+    "id": "a1234567-89ab-cdef-0123-456789abcdef",
+    "time": 1477502783,
+    "user": {
+      "user_id": "0123456789abcdef01234567",
+      "external_user_id": "user_id",
+      "timezone": "America/Chicago"
+    },
+    "properties": {
+      "app_id": "01234567-89ab-cdef-0123-456789abcdef",
+      "campaign_id": "11234567-89ab-cdef-0123-456789abcdef",
+      "campaign_name": "Test Campaign",
+      "message_variation_id": "c1234567-89ab-cdef-0123-456789abcdef",
+      "message_variation_name": "Test Message Variation",
+      "canvas_id": "21234567-89ab-cdef-0123-456789abcdef",
+      "canvas_variation_id": "31234567-89ab-cdef-0123-456789abcdef",
+      "canvas_step_id": "41234567-89ab-cdef-0123-456789abcdef",
+      "canvas_name": "Test Canvas",
+      "canvas_variation_name": "Test Canvas Variation Name",
+      "canvas_step_name": "Test Canvas Step Name",
+      "subscription_status": "subscribed",
+      "channel": "email",
+      "email_address": "test@test.com",
+      "send_id": "f123456789abcdef01234567",
+      "state_change_source": "r"
+    }
+  }

--- a/sample-data/Custom HTTP/users/behaviors/subscriptiongroup/StateChange.json
+++ b/sample-data/Custom HTTP/users/behaviors/subscriptiongroup/StateChange.json
@@ -1,0 +1,30 @@
+{
+    "event_type": "users.behaviors.subscriptiongroup.StateChange",
+    "id": "a1234567-89ab-cdef-0123-456789abcdef",
+    "time": 1477502783,
+    "user": {
+      "user_id": "0123456789abcdef01234567",
+      "external_user_id": "user_id",
+      "timezone": "America/Chicago"
+    },
+    "properties": {
+      "app_id": "01234567-89ab-cdef-0123-456789abcdef",
+      "phone_number": "+16462345678",
+      "campaign_id": "11234567-89ab-cdef-0123-456789abcdef",
+      "campaign_name": "Test Campaign",
+      "message_variation_id": "c1234567-89ab-cdef-0123-456789abcdef",
+      "message_variation_name": "Test Message Variation",
+      "canvas_id": "21234567-89ab-cdef-0123-456789abcdef",
+      "canvas_variation_id": "31234567-89ab-cdef-0123-456789abcdef",
+      "canvas_step_id": "41234567-89ab-cdef-0123-456789abcdef",
+      "canvas_name": "Test Canvas",
+      "canvas_variation_name": "Test Canvas Variation Name",
+      "canvas_step_name": "Test Canvas Step Name",
+      "subscription_group_id": "41234567-89ab-cdef-0123-456789abcdef",
+      "subscription_status": "subscribed",
+      "channel": "email",
+      "email_address": "test@test.com",
+      "send_id": "f123456789abcdef01234567",
+      "state_change_source": "r"
+    }
+  }


### PR DESCRIPTION
#### 🎫  JIRA https://jira.braze.com/browse/DI-6121

Useful link: 
https://github.com/Appboy/currents-users-events/tree/master/test-records/expected-records/customhttp/users/behaviors

I am not sure if I did the right thing here. I went through our currents-users-events repo and added any json file that was missing from currents-example for customhttp using this logic:
Create the json file at the directory depth represented in currents-users-events
For example SessionEnd.json lives inside app.
<img width="288" alt="image" src="https://github.com/Appboy/currents-examples/assets/89039596/1bec213e-5d8f-4463-a7f0-f77dce9edda8">
while Location.json is at the root level because the json file in currents-users-events is at the root level


#### 🔖  Summary
Description of changes go here

#### 💪  Test Steps
- Detailed test steps go down here
  - There can also be sub-cases
- Do any manual testing? Add it here too

